### PR TITLE
Change runner from ubuntu-slim to ubuntu-latest

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -40,7 +40,7 @@ jobs:
       github.event_name != 'workflow_run' ||
       (github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.head_repository.full_name == github.repository)
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     timeout-minutes: 360
 
     steps:


### PR DESCRIPTION
Must use ubuntu-latest to avoid the 15 minute max time for ubuntu-slim runners